### PR TITLE
Hw 23

### DIFF
--- a/HW_23/Makefile
+++ b/HW_23/Makefile
@@ -1,0 +1,43 @@
+
+limit::
+	ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory -l $(L) provision.yaml
+
+install:: up
+	@ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory provisioning/playbook.yml 
+stop::
+	@vagrant destroy -f
+up::
+	@vagrant up
+test::
+	@echo "############## RUN TEST dig client"
+	@echo "Run client dig +short www.newdns.lab @192.168.50.10"
+	@vagrant ssh client -c "dig +short www.newdns.lab @192.168.50.10"
+	@echo "Run client dig +short web1.dns.lab @192.168.50.10"
+	@vagrant ssh client -c "dig +short web1.dns.lab @192.168.50.10"
+	@echo "Run client dig +short web2.dns.lab @192.168.50.10"
+	@vagrant ssh client -c "dig +short web2.dns.lab @192.168.50.10"
+
+	@echo "############## RUN TEST dig client2"
+	@echo "Run client2 dig +short www.newdns.lab @192.168.50.10"
+	@vagrant ssh client2 -c "dig +short www.newdns.lab @192.168.50.10"
+	@echo "Run client2 dig +short web1.dns.lab @192.168.50.10"
+	@vagrant ssh client2 -c "dig +short web1.dns.lab @192.168.50.10"
+	@echo "Run client2 dig +short web2.dns.lab @192.168.50.10"
+	@vagrant ssh client2 -c "dig +short web2.dns.lab @192.168.50.10"
+
+
+	@echo "############## RUN TEST dig client SLAVE"
+	@echo "Run client dig +short www.newdns.lab @192.168.50.11"
+	@vagrant ssh client -c "dig +short www.newdns.lab @192.168.50.11"
+	@echo "Run client dig +short web1.dns.lab @192.168.50.11"
+	@vagrant ssh client -c "dig +short web1.dns.lab @192.168.50.11"
+	@echo "Run client dig +short web2.dns.lab @192.168.50.11"
+	@vagrant ssh client -c "dig +short web2.dns.lab @192.168.50.11"
+
+	@echo "############## RUN TEST dig client2 SLAVE"
+	@echo "Run client2 dig +short www.newdns.lab @192.168.50.11"
+	@vagrant ssh client2 -c "dig +short www.newdns.lab @192.168.50.11"
+	@echo "Run client2 dig +short web1.dns.lab @192.168.50.11"
+	@vagrant ssh client2 -c "dig +short web1.dns.lab @192.168.50.11"
+	@echo "Run client2 dig +short web2.dns.lab @192.168.50.11"
+	@vagrant ssh client2 -c "dig +short web2.dns.lab @192.168.50.11"

--- a/HW_23/README.md
+++ b/HW_23/README.md
@@ -46,3 +46,29 @@ A Bind's DNS lab with Vagrant and Ansible, based on CentOS 7.
     * used to test the env, runs rndc and nsupdate
   * zone transfer: TSIG key
 ```
+
+## Описание
+
+### Запуск стенда
+
+- установка Ansible
+
+    ```bash
+    cd HW_20
+    python3.8 -m venv venv
+    source venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
+    ```
+
+- Запуск виртуальных машин и настройка окружения.
+
+    ```bash
+    make install
+    ```
+
+- Запуск теста доступности. Проверяет dig с клиента_1 и клиента_2, ошибки не выдает, но по выводу можно понять работает стенд как надо или нет.
+
+    ```bash
+    make test
+    ```

--- a/HW_23/README.md
+++ b/HW_23/README.md
@@ -25,3 +25,24 @@ www - смотрит на обоих клиентов
 5 - сделано основное задание
 6 - выполнено задания со звездочкой 
 ```
+
+```txt
+# Vagrant DNS Lab
+
+A Bind's DNS lab with Vagrant and Ansible, based on CentOS 7.
+
+# Playground
+
+<code>
+    vagrant ssh client
+</code>
+
+  * zones: dns.lab, reverse dns.lab and ddns.lab
+  * ns01 (192.168.50.10)
+    * master, recursive, allows update to ddns.lab
+  * ns02 (192.168.50.11)
+    * slave, recursive
+  * client (192.168.50.15)
+    * used to test the env, runs rndc and nsupdate
+  * zone transfer: TSIG key
+```

--- a/HW_23/Vagrantfile
+++ b/HW_23/Vagrantfile
@@ -1,0 +1,41 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "centos/7"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.provision "ansible" do |ansible|
+    # ansible.verbose = "vvv"
+    ansible.playbook = "provisioning/playbook.yml"
+    ansible.become = true
+    ansible.host_key_checking = false
+    ansible.groups = { 
+        "clients" => [ "client2", "client" ]
+    }
+  end
+
+
+  config.vm.provider "virtualbox" do |v|
+	  v.memory = 256
+  end
+
+  config.vm.define "ns01" do |ns01|
+    ns01.vm.network "private_network", ip: "192.168.50.10", virtualbox__intnet: "dns"
+    ns01.vm.hostname = "ns01"
+  end
+
+  config.vm.define "ns02" do |ns02|
+    ns02.vm.network "private_network", ip: "192.168.50.11", virtualbox__intnet: "dns"
+    ns02.vm.hostname = "ns02"
+  end
+
+  config.vm.define "client" do |client|
+    client.vm.network "private_network", ip: "192.168.50.15", virtualbox__intnet: "dns"
+    client.vm.hostname = "client"
+  end
+
+  config.vm.define "client2" do |client2|
+    client2.vm.network "private_network", ip: "192.168.50.16", virtualbox__intnet: "dns"
+    client2.vm.hostname = "client2"
+  end
+end

--- a/HW_23/ansible.cfg
+++ b/HW_23/ansible.cfg
@@ -1,0 +1,86 @@
+
+# [defaults]
+# inventory = ./hosts
+# become = yes
+# host_key_checking = false
+# nocows = 1
+# ANSIBLE_PLAYBOOK_VARS_ROOT = ./
+# eprecation_warnings = False
+
+
+[defaults]
+fact_caching            = jsonfile
+fact_caching_connection = /tmp/facts_cache
+fact_caching_timeout    = 7200
+inventory               = ./inventory
+library                 = ./modules
+roles_path              = ./roles
+COLLECTIONS_PATHS       = ./collection
+remote_tmp              = $HOME/.ansible/tmp
+local_tmp               = $HOME/.ansible/tmp
+log_path                = $HOME/ansible.log
+nocows                  = 1
+ANSIBLE_PLAYBOOK_VARS_ROOT = ./
+forks                   = 8
+poll_interval           = 15
+ask_vault_pass          = False
+ask_pass                = False
+transport               = smart
+remote_port             = 22
+gathering               = smart
+gather_subset           = all
+host_key_checking       = False
+# stdout_callback         = skippy
+stdout_callback         = yaml
+callback_whitelist      = timer
+timeout                 = 60
+module_name             = command
+executable              = /bin/bash
+# hash_behaviour          = replace
+private_role_vars       = yes
+jinja2_extensions       = jinja2.ext.do,jinja2.ext.i18n
+private_key_file        = $HOME/.ssh/id_rsa
+display_skipped_hosts   = True
+display_args_to_stdout  = False
+error_on_undefined_vars = False
+system_warnings         = True
+deprecation_warnings    = True
+command_warnings        = False
+bin_ansible_callbacks   = False
+var_compression_level   = 9
+force_color             = 1
+retry_files_enabled     = False
+
+[privilege_escalation]
+become        =True
+become_method =sudo
+
+[paramiko_connection]
+
+[ssh_connection]
+ssh_args        = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+control_path    = /tmp/ansible-ssh-%%h-%%p-%%r
+pipelining      = True
+scp_if_ssh      = True
+sftp_batch_mode = False
+
+[colors]
+highlight   = white
+verbose     = blue
+warn        = bright purple
+error       = red
+debug       = dark gray
+deprecate   = purple
+skip        = cyan
+unreachable = red
+ok          = green
+changed     = yellow
+diff_add    = green
+diff_remove = red
+diff_lines  = cyan
+
+[diff]
+# Always print diff when running ( same as always running with -D/--diff )
+always = True
+# Set how many context lines to show in diff
+context = 3

--- a/HW_23/provisioning/client-motd
+++ b/HW_23/provisioning/client-motd
@@ -1,0 +1,17 @@
+### Welcome to the DNS lab! ###
+
+- Use this client to test the enviroment, with dig or nslookup.
+    dig @192.168.50.10 ns01.dns.lab
+    dig @192.168.50.11 -x 192.168.50.10
+
+- nsupdate is available in the ddns.lab zone. Ex:
+    nsupdate -k /etc/named.zonetransfer.key
+    server 192.168.50.10
+    zone ddns.lab 
+    update add www.ddns.lab. 60 A 192.168.50.15
+    send
+
+- rndc is also available to manage the servers
+    rndc -c ~/rndc.conf reload
+
+Enjoy!

--- a/HW_23/provisioning/client-resolv.conf
+++ b/HW_23/provisioning/client-resolv.conf
@@ -1,0 +1,4 @@
+domain dns.lab
+search dns.lab
+nameserver 192.168.50.10
+nameserver 192.168.50.11

--- a/HW_23/provisioning/master-named.conf
+++ b/HW_23/provisioning/master-named.conf
@@ -1,0 +1,140 @@
+options {
+
+    // network 
+	listen-on port 53 { 192.168.50.10; };
+	listen-on-v6 port 53 { ::1; };
+
+    // data
+	directory 	"/var/named";
+	dump-file 	"/var/named/data/cache_dump.db";
+	statistics-file "/var/named/data/named_stats.txt";
+	memstatistics-file "/var/named/data/named_mem_stats.txt";
+
+    // server
+	recursion yes;
+	allow-query     { any; };
+    allow-transfer { any; };
+    
+    // dnssec
+	dnssec-enable yes;
+	dnssec-validation yes;
+
+    // others
+	bindkeys-file "/etc/named.iscdlv.key";
+	managed-keys-directory "/var/named/dynamic";
+	pid-file "/run/named/named.pid";
+	session-keyfile "/run/named/session.key";
+};
+
+acl "client1" {!key client2.key; key zonetransfer.key; 192.168.50.15/32; 127.0.0.1/32; 192.168.50.10/32;  192.168.50.11/32;};
+acl "client2" {!key zonetransfer.key;key client2.key; 192.168.50.16/32; 127.0.0.1/32; 192.168.50.10/32;  192.168.50.11/32;};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+// RNDC Control for client
+key "rndc-key" {
+    algorithm hmac-md5;
+    secret "GrtiE9kz16GK+OKKU/qJvQ==";
+};
+key "client2.key" {
+	algorithm hmac-md5;
+	secret "K+h5aoe86kvYUCJC0gwWKg==";
+};
+
+
+controls {
+        inet 192.168.50.10 allow { 192.168.50.15; } keys { "rndc-key"; }; 
+};
+
+// ZONE TRANSFER WITH TSIG
+include "/etc/named.zonetransfer.key"; 
+
+
+view "client1" {
+# server 192.168.50.11 {
+#     keys { "zonetransfer.key"; };
+# };
+        match-clients {"client1"; };
+        allow-recursion { 192.168.50.0/24; 127.0.0.1; };
+        allow-transfer { 192.168.50.11; key zonetransfer.key;};
+        // root zone
+        zone "." IN {
+            type hint;
+            file "named.ca";
+        };
+
+        // zones like localhost
+        include "/etc/named.rfc1912.zones";
+        // root's DNSKEY
+        include "/etc/named.root.key";
+
+        // lab's zone
+        zone "dns.lab" {
+            type master;
+            allow-transfer { key "zonetransfer.key"; };
+            file "/etc/named/named.dns.lab";
+        };
+
+        // lab's zone reverse
+        zone "50.168.192.in-addr.arpa" {
+            type master;
+            allow-transfer { key "zonetransfer.key"; };
+            file "/etc/named/named.dns.lab.rev";
+        };
+
+        // lab's ddns zone
+        zone "ddns.lab" {
+            type master;
+            allow-transfer { key "zonetransfer.key"; };
+            allow-update { key "zonetransfer.key"; };
+            file "/etc/named/named.ddns.lab";
+        };
+
+        // lab's newdns zone
+        zone "newdns.lab" {
+            type master;
+            allow-transfer { key "zonetransfer.key"; };
+            allow-update { key "zonetransfer.key"; };
+            file "/etc/named/named.newdns.lab";
+        };
+
+};
+
+view "client2" {
+# server 192.168.50.11 {
+#     keys { "zonetransfer.key"; };
+# };
+        match-clients {"client2"; };
+        allow-recursion { 192.168.50.0/24; 127.0.0.1; };
+        allow-transfer { 192.168.50.11; key client2.key;};
+        // root zone
+        zone "." IN {
+            type hint;
+            file "named.ca";
+        };
+
+        // zones like localhost
+        include "/etc/named.rfc1912.zones";
+        // root's DNSKEY
+        include "/etc/named.root.key";
+
+        // lab's zone
+        zone "dns.lab" {
+            type master;
+            allow-transfer { key "client2.key"; };
+            file "/etc/named/named.client2.dns.lab";
+        };
+
+        // lab's zone reverse
+        zone "50.168.192.in-addr.arpa" {
+            type master;
+            allow-transfer { key "client2.key"; };
+            file "/etc/named/named.dns.lab.rev";
+        };
+
+};

--- a/HW_23/provisioning/named.client2.dns.lab
+++ b/HW_23/provisioning/named.client2.dns.lab
@@ -1,0 +1,18 @@
+$TTL 3600
+$ORIGIN dns.lab.
+@               IN      SOA     ns01.dns.lab. root.dns.lab. (
+                            2020120902 ; serial
+                            3600       ; refresh (1 hour)
+                            600        ; retry (10 minutes)
+                            86400      ; expire (1 day)
+                            600        ; minimum (10 minutes)
+                        )
+
+                IN      NS      ns01.dns.lab.
+                IN      NS      ns02.dns.lab.
+
+; DNS Servers
+ns01            IN      A       192.168.50.10
+ns02            IN      A       192.168.50.11
+web1            IN      A       192.168.50.15
+web2            IN      A       192.168.50.16

--- a/HW_23/provisioning/named.ddns.lab
+++ b/HW_23/provisioning/named.ddns.lab
@@ -1,0 +1,16 @@
+$TTL 3600
+$ORIGIN ddns.lab.
+@               IN      SOA     ns01.dns.lab. root.dns.lab. (
+                            2711201407 ; serial
+                            3600       ; refresh (1 hour)
+                            600        ; retry (10 minutes)
+                            86400      ; expire (1 day)
+                            600        ; minimum (10 minutes)
+                        )
+
+                IN      NS      ns01.dns.lab.
+                IN      NS      ns02.dns.lab.
+
+; DNS Servers
+ns01            IN      A       192.168.50.10
+ns02            IN      A       192.168.50.11

--- a/HW_23/provisioning/named.dns.lab
+++ b/HW_23/provisioning/named.dns.lab
@@ -1,0 +1,18 @@
+$TTL 3600
+$ORIGIN dns.lab.
+@               IN      SOA     ns01.dns.lab. root.dns.lab. (
+                            2020120902 ; serial
+                            3600       ; refresh (1 hour)
+                            600        ; retry (10 minutes)
+                            86400      ; expire (1 day)
+                            600        ; minimum (10 minutes)
+                        )
+
+                IN      NS      ns01.dns.lab.
+                IN      NS      ns02.dns.lab.
+
+; DNS Servers
+ns01            IN      A       192.168.50.10
+ns02            IN      A       192.168.50.11
+web1            IN      A       192.168.50.15
+;web2            IN      A       192.168.50.16

--- a/HW_23/provisioning/named.dns.lab.rev
+++ b/HW_23/provisioning/named.dns.lab.rev
@@ -1,0 +1,18 @@
+$TTL 3600
+$ORIGIN 50.168.192.in-addr.arpa.
+50.168.192.in-addr.arpa.  IN      SOA     ns01.dns.lab. root.dns.lab. (
+                            2020120902 ; serial
+                            3600       ; refresh (1 hour)
+                            600        ; retry (10 minutes)
+                            86400      ; expire (1 day)
+                            600        ; minimum (10 minutes)
+                        )
+
+                IN      NS      ns01.dns.lab.
+                IN      NS      ns02.dns.lab.
+
+; DNS Servers
+10              IN      PTR     ns01.dns.lab.
+11              IN      PTR     ns02.dns.lab.
+15              IN      PTR     web1.dns.lab.
+16              IN      PTR     web2.dns.lab.

--- a/HW_23/provisioning/named.newdns.lab
+++ b/HW_23/provisioning/named.newdns.lab
@@ -1,0 +1,17 @@
+$TTL 3600
+$ORIGIN newdns.lab.
+@               IN      SOA     ns01.dns.lab. root.dns.lab. (
+                            2020120901 ; serial
+                            3600       ; refresh (1 hour)
+                            600        ; retry (10 minutes)
+                            86400      ; expire (1 day)
+                            600        ; minimum (10 minutes)
+                        )
+
+                IN      NS      ns01.dns.lab.
+                IN      NS      ns02.dns.lab.
+
+; DNS Servers
+
+www            IN      A       192.168.50.15
+www            IN      A       192.168.50.16

--- a/HW_23/provisioning/named.zonetransfer.key
+++ b/HW_23/provisioning/named.zonetransfer.key
@@ -1,0 +1,4 @@
+key "zonetransfer.key" {
+    algorithm hmac-md5;
+    secret "SB4Db9pJomyKxTNynlAq/g==";
+};

--- a/HW_23/provisioning/playbook.yml
+++ b/HW_23/provisioning/playbook.yml
@@ -1,0 +1,62 @@
+---
+- hosts: all
+  become: yes
+  tasks:
+  - name: install packages
+    yum: name={{ item }} state=latest 
+    with_items:
+      - bind
+      - bind-utils
+      - ntp
+
+  - name: copy transferkey to all servers and the client
+    copy: src=named.zonetransfer.key dest=/etc/named.zonetransfer.key owner=named group=named mode=0600
+
+- hosts: ns01
+  become: yes
+  tasks:
+  - name: copy named.conf
+    copy: src=master-named.conf dest=/etc/named.conf owner=root group=named mode=0640
+  - name: copy zones
+    copy: src={{ item }} dest=/etc/named/ owner=root group=named mode=0660
+    with_fileglob:
+      - named.*
+  - name: copy resolv.conf to the servers
+    copy: src=servers-resolv.conf dest=/etc/resolv.conf owner=root group=root mode=0644
+  
+  - name: set /etc/named permissions
+    file: path=/etc/named owner=root group=named mode=0670
+  - name: set new context named
+    command: semanage fcontext -a -t named_zone_t "/etc/named(/.*)?"
+  - name: restore context
+    command: restorecon -R /etc/named
+
+  - name: ensure named is running and enabled
+    service: name=named state=restarted enabled=yes
+
+- hosts: ns02
+  become: yes
+  tasks:
+  - name: copy named.conf
+    copy: src=slave-named.conf dest=/etc/named.conf owner=root group=named mode=0640
+  - name: copy resolv.conf to the servers
+    copy: src=servers-resolv.conf dest=/etc/resolv.conf owner=root group=root mode=0644
+
+  - name: set /etc/named permissions
+    file: path=/etc/named owner=root group=named mode=0670
+  - name: set new context named
+    command: semanage fcontext -a -t named_zone_t "/etc/named(/.*)?"
+  - name: restore context
+    command: restorecon -R /etc/named
+  - name: ensure named is running and enabled
+    service: name=named state=restarted enabled=yes
+    
+- hosts: clients
+  become: yes
+  tasks:
+  - name: copy resolv.conf to the client
+    copy: src=client-resolv.conf dest=/etc/resolv.conf owner=root group=root mode=0644
+  - name: copy rndc conf file
+    copy: src=rndc.conf dest=/home/vagrant/rndc.conf owner=vagrant group=vagrant mode=0644
+  - name: copy motd to the client
+    copy: src=client-motd dest=/etc/motd owner=root group=root mode=0644

--- a/HW_23/provisioning/rndc.conf
+++ b/HW_23/provisioning/rndc.conf
@@ -1,0 +1,9 @@
+key "rndc-key" {
+    algorithm hmac-md5;
+    secret "GrtiE9kz16GK+OKKU/qJvQ==";
+};
+
+options {
+    default-key "rndc-key";
+    default-server 192.168.50.10; 
+};

--- a/HW_23/provisioning/servers-resolv.conf
+++ b/HW_23/provisioning/servers-resolv.conf
@@ -1,0 +1,3 @@
+domain dns.lab
+search dns.lab
+nameserver 127.0.0.1

--- a/HW_23/provisioning/slave-named.conf
+++ b/HW_23/provisioning/slave-named.conf
@@ -1,0 +1,132 @@
+options {
+
+    // network 
+	listen-on port 53 { 192.168.50.11; };
+	listen-on-v6 port 53 { ::1; };
+
+    // data
+	directory 	"/var/named";
+	dump-file 	"/var/named/data/cache_dump.db";
+	statistics-file "/var/named/data/named_stats.txt";
+	memstatistics-file "/var/named/data/named_mem_stats.txt";
+
+    // server
+	recursion yes;
+	allow-query     { any; };
+    allow-transfer { any; };
+    
+    // dnssec
+	dnssec-enable yes;
+	dnssec-validation yes;
+
+    // others
+	bindkeys-file "/etc/named.iscdlv.key";
+	managed-keys-directory "/var/named/dynamic";
+	pid-file "/run/named/named.pid";
+	session-keyfile "/run/named/session.key";
+};
+
+acl "client1" {!key client2.key; key zonetransfer.key; 192.168.50.15/32; 127.0.0.1/32; 192.168.50.10/32;  192.168.50.11/32;};
+acl "client2" {!key zonetransfer.key;key client2.key; 192.168.50.16/32; 127.0.0.1/32; 192.168.50.10/32;  192.168.50.11/32;};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+// RNDC Control for client
+key "rndc-key" {
+    algorithm hmac-md5;
+    secret "GrtiE9kz16GK+OKKU/qJvQ==";
+};
+key "client2.key" {
+	algorithm hmac-md5;
+	secret "K+h5aoe86kvYUCJC0gwWKg==";
+};
+
+controls {
+        inet 192.168.50.11 allow { 192.168.50.15; } keys { "rndc-key"; };
+};      
+
+// ZONE TRANSFER WITH TSIG
+include "/etc/named.zonetransfer.key"; 
+
+
+view "client1" {
+# server 192.168.50.10 {
+#     keys { "zonetransfer.key"; };
+# };
+        match-clients {"client1"; };
+        allow-recursion { 192.168.50.0/24; 127.0.0.1; };
+        // root zone
+        zone "." IN {
+            type hint;
+            file "named.ca";
+        };
+
+        // zones like localhost
+        include "/etc/named.rfc1912.zones";
+        // root's DNSKEY
+        include "/etc/named.root.key";
+
+        // lab's zone
+        zone "dns.lab" {
+            type slave;
+            masters { 192.168.50.10 key zonetransfer.key; };
+            file "/etc/named/named.dns.lab";
+        };
+
+        // lab's zone reverse
+        zone "50.168.192.in-addr.arpa" {
+            type slave;
+            masters { 192.168.50.10 key zonetransfer.key; };
+            file "/etc/named/named.dns.lab.rev";
+        };
+
+        // lab's ddns zone
+        zone "ddns.lab" {
+            type slave;
+            masters { 192.168.50.10 key zonetransfer.key; };
+            file "/etc/named/named.ddns.lab";
+        };
+        // lab's newdns zone
+        zone "newdns.lab" {
+            type slave;
+            masters { 192.168.50.10 key zonetransfer.key; };
+            file "/etc/named/named.newdns.lab";
+        };
+};
+
+view "client2" {
+        match-clients {"client2"; };
+        allow-recursion { 192.168.50.0/24; 127.0.0.1; };
+
+                // root zone
+        zone "." IN {
+            type hint;
+            file "named.ca";
+        };
+
+        // zones like localhost
+        include "/etc/named.rfc1912.zones";
+        // root's DNSKEY
+        include "/etc/named.root.key";
+
+        // lab's zone
+        zone "dns.lab" {
+            type slave;
+            masters { 192.168.50.10 key client2.key; };
+            file "/etc/named/named.client2.dns.lab";
+        };
+
+        // lab's zone reverse
+        zone "50.168.192.in-addr.arpa" {
+            type slave;
+            masters { 192.168.50.10 key client2.key; };
+            file "/etc/named/named.client2.dns.lab.rev";
+        };
+
+
+};

--- a/HW_23/provisioning/zonetransfer.key
+++ b/HW_23/provisioning/zonetransfer.key
@@ -1,0 +1,4 @@
+key "zonetransfer.key" {
+    algorithm hmac-md5;
+    secret "SB4Db9pJomyKxTNynlAq/g==";
+};


### PR DESCRIPTION
# DNS

## Домашнее Задание

```txt
настраиваем split-dns
взять стенд https://github.com/erlong15/vagrant-bind
добавить еще один сервер client2
завести в зоне dns.lab
имена
web1 - смотрит на клиент1
web2 смотрит на клиент2

завести еще одну зону newdns.lab
завести в ней запись
www - смотрит на обоих клиентов

настроить split-dns
клиент1 - видит обе зоны, но в зоне dns.lab только web1

клиент2 видит только dns.lab

*) настроить все без выключения selinux
Критерии оценки: 4 - основное задание сделано, но есть вопросы
5 - сделано основное задание
6 - выполнено задания со звездочкой 
```

```txt
# Vagrant DNS Lab

A Bind's DNS lab with Vagrant and Ansible, based on CentOS 7.

# Playground

<code>
    vagrant ssh client
</code>

  * zones: dns.lab, reverse dns.lab and ddns.lab
  * ns01 (192.168.50.10)
    * master, recursive, allows update to ddns.lab
  * ns02 (192.168.50.11)
    * slave, recursive
  * client (192.168.50.15)
    * used to test the env, runs rndc and nsupdate
  * zone transfer: TSIG key
```

## Описание

### Запуск стенда

- установка Ansible

    ```bash
    cd HW_20
    python3.8 -m venv venv
    source venv/bin/activate
    pip install --upgrade pip
    pip install -r requirements.txt
    ```

- Запуск виртуальных машин и настройка окружения.

    ```bash
    make install
    ```

- Запуск теста доступности. Проверяет dig с клиента_1 и клиента_2, ошибки не выдает, но по выводу можно понять работает стенд как надо или нет.

    ```bash
    make test
    ```
